### PR TITLE
Unpin dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ include = [ "LICENSE", "NOTICE" ]
 [tool.poetry.dependencies]
 python = ">=3.8"
 numpy = ">=1.0"
-xobjects = "^0.2.6"
-xdeps = "^0.1.1"
-xpart = "^0.15.0"
-xtrack = "^0.36.5"
-xfields = "^0.12.1"
-xcoll = "^0.2.1"
+xobjects = ">=0.2.6"
+xdeps = ">=0.1.1"
+xpart = ">=0.15.0"
+xtrack = ">=0.36.5"
+xfields = ">=0.12.1"
+xcoll = ">=0.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = ">7"


### PR DESCRIPTION
## Description

Currently the installation of xboinc downgrades xtrack, because the dependencies are pinned. This unpins them. I have ran the tests with the most recent packages and they pass.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
