### PR TITLE
Bump version to 0.1.8 and update xsuite dependencies in pyproject.tom…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ include = [ "LICENSE", "NOTICE" ]
 [tool.poetry.dependencies]
 python   = '>=3.8'
 numpy    = '>=1.0'
-xobjects = '==0.2.10'
-xdeps    = '==0.5.2'
-xpart    = '==0.16.3'
-xtrack   = '==0.48.1'
-xfields  = '==0.15.0'
-xcoll    = '==0.2.7'
-xaux    =  '==0.1.2'
+xobjects = '==0.5.0'
+xdeps    = '==0.10.5'
+xpart    = '==0.23.0'
+xtrack   = '==0.84.7'
+xfields  = '==0.24.0'
+xcoll    = '==0.6.1'
+xaux     = '==0.3.5'
 
 [poetry.group.dev.dependencies]
 pytest = ">7"

--- a/xboinc/executable/Makefile
+++ b/xboinc/executable/Makefile
@@ -13,6 +13,12 @@
 
 # This should work on Linux.  Modify as needed for other platforms.
 
+# If needed, set the BOINC_DIR to the location of your BOINC installation.
+# BOINC_DIR = /home/boincadm/boinc
+
+# If needed, set the directory where the xtrack Python package is installed.
+# XTRACK_PYTHON_DIR = /home/boincadm/anaconda3/lib/python3.13/site-packages/xtrack
+
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 BOINC_SOURCE_ZIP_DIR = $(BOINC_DIR)/zip
@@ -28,6 +34,7 @@ MAKEFILE_LDFLAGS = -lpthread $(MAKEFILE_STDLIB) -static
 CXXFLAGS += \
     -Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wunused-parameter -Wno-write-strings -fno-common \
     -O2 \
+	-I$(XTRACK_PYTHON_DIR) \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \
     -I$(BOINC_SOURCE_LIB_DIR) \
@@ -37,7 +44,13 @@ CXXFLAGS += \
     -L$(BOINC_LIB_DIR) \
     -L/usr/X11R6/lib \
     -L/usr/lib \
-    -L.
+    -L. \
+	-DXO_CONTEXT_CPU \
+	-DXO_CONTEXT_CPU_OPENMP
+# These last two flags are now needed for the xtrack Python package
+# to compile the xboinc executable correctly
+# For GPU context, different flags are needed, but we are not using them here for now.
+# For CPU context, single core, we can use -DXO_CONTEXT_CPU_SERIAL instead of -DXO_CONTEXT_CPU_OPENMP.
 
 # to get the graphics app to compile you may need to install some packages
 # e.g. ftgl-devel.x86_64
@@ -95,7 +108,7 @@ install: xboinc
 # because otherwise, you might get a version in /usr/lib etc.
 
 xtrack.o: xtrack_tracker.h xb_input.h xtrack.c
-	$(CC) $(CXXFLAGS) -lm -std=c99 -c xtrack.c
+	$(CXX) $(CXXFLAGS) -lm -x c -std=c99 -c xtrack.c
 
 xboinc_test: xtrack.o xtrack.h main.c $(MAKEFILE_STDLIB)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -o xboinc_test xtrack.o main.c -lm $(MAKEFILE_LDFLAGS)

--- a/xboinc/general.py
+++ b/xboinc/general.py
@@ -13,20 +13,19 @@ _pkg_root = Path(__file__).parent.absolute()
 # Do not change
 # ==========================================================================================
 
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 
 # These are the xsuite modules that are used by boinc and the versions they are tied to.
 # This will be automatically updated from the active environment when making a minor release.
 # If a new package needs to be pinned, add it here with a random version number,
 # and similarily in the pyproject.toml
 __xsuite__versions__ = {
-    'xobjects' : '0.2.10',
-    'xdeps'    : '0.5.2',
-    'xpart'    : '0.16.3',
-    'xtrack'   : '0.48.1',
-    'xfields'  : '0.15.0',
-    'xcoll'    : '0.2.7',
-    'xaux'     : '0.1.2',
+    'xobjects' : '0.5.0',
+    'xdeps'    : '0.10.5',
+    'xpart'    : '0.23.0',
+    'xtrack'   : '0.84.7',
+    'xfields'  : '0.24.0',
+    'xcoll'    : '0.6.1',
+    'xaux'     : '0.3.5',
 }
-
 # ==========================================================================================

--- a/xboinc/register.py
+++ b/xboinc/register.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from .general import _pkg_root
 from .user import update_user_data, get_user_data, remove_user
-from .server import server_account, dropdir, assert_eos_accessible, fs_exists, fs_rm, fs_cp,\
+from .server import server_account, dropdir, fs_exists, fs_rm, fs_cp,\
                     afs_add_acl, afs_remove_acl, on_afs, on_eos, fs_path, fs_rename
 
 

--- a/xboinc/simulation_io/default_tracker.py
+++ b/xboinc/simulation_io/default_tracker.py
@@ -15,61 +15,131 @@ import xfields as xf
 import xobjects as xo
 import xcoll as xc
 
+from xtrack.beam_elements import *
+from xtrack.monitors import *
+from xtrack.random import *
+from xtrack.multisetter import MultiSetter
+
 from .version import assert_versions
 
+ONLY_XTRACK_ELEMENTS = [
+    Drift,
+    Multipole,
+    Bend,
+    RBend,
+    Quadrupole,
+    Sextupole,
+    Octupole,
+    Magnet,
+    SecondOrderTaylorMap,
+    Marker,
+    ReferenceEnergyIncrease,
+    Cavity,
+    Elens,
+    Wire,
+    Solenoid,
+    RFMultipole,
+    DipoleEdge,
+    MultipoleEdge,
+    SimpleThinBend,
+    SimpleThinQuadrupole,
+    LineSegmentMap,
+    FirstOrderTaylorMap,
+    NonLinearLens,
+    # Slices
+    DriftSlice,
+    DriftSliceBend,
+    DriftSliceRBend,
+    DriftSliceOctupole,
+    DriftSliceQuadrupole,
+    DriftSliceSextupole,
+    ThickSliceBend,
+    ThickSliceRBend,
+    ThickSliceOctupole,
+    ThickSliceQuadrupole,
+    ThickSliceSextupole,
+    ThickSliceSolenoid,
+    ThinSliceBend,
+    ThinSliceRBend,
+    ThinSliceBendEntry,
+    ThinSliceBendExit,
+    ThinSliceRBendEntry,
+    ThinSliceRBendExit,
+    ThinSliceQuadrupoleEntry,
+    ThinSliceQuadrupoleExit,
+    ThinSliceSextupoleEntry,
+    ThinSliceSextupoleExit,
+    ThinSliceOctupoleEntry,
+    ThinSliceOctupoleExit,
+    ThinSliceOctupole,
+    ThinSliceQuadrupole,
+    ThinSliceSextupole,
+    # Transformations
+    XYShift,
+    ZetaShift,
+    XRotation,
+    SRotation,
+    YRotation,
+    # Apertures
+    LimitEllipse,
+    LimitRectEllipse,
+    LimitRect,
+    LimitRacetrack,
+    LimitPolygon,
+    LongitudinalLimitRect,
+    # Monitors
+    BeamPositionMonitor,
+    BeamSizeMonitor,
+    BeamProfileMonitor,
+    LastTurnsMonitor,
+    ParticlesMonitor,
+]
 
-default_element_classes = [
-            xt.Marker,
-            xt.Drift,
-            # xt.CombinedFunctionMagnet  # deprecated
-            xt.Bend,
-            xt.Multipole,
-            xt.Quadrupole,
-            xt.Sextupole,
-            xt.SimpleThinBend,
-            xt.SimpleThinQuadrupole,
-            xt.ReferenceEnergyIncrease,
-            xt.Cavity,
-            xt.Solenoid,
-            xt.XYShift,
-            xt.Elens,
-            xt.NonLinearLens,
-            xt.Wire,
-            xt.SRotation,
-            xt.XRotation,
-            xt.YRotation,
-            xt.ZetaShift,
-            xt.RFMultipole,
-            # xt.Fringe,  # untested
-            # xt.Wedge,   # untested
-            xt.DipoleEdge,
-            xt.Exciter,
-            # xt.LinearTransferMatrix  # deprecated
-            xt.LineSegmentMap,
-            xt.FirstOrderTaylorMap,
-            xt.SecondOrderTaylorMap,
-            xf.BeamBeamBiGaussian2D,
-            xf.BeamBeamBiGaussian3D,
-            # # Doesn't work because fieldmap in different buffer
-            # xf.ElectronCloud,
-            # xf.ElectronLensInterpolated,
-            xc.BlackAbsorber,
-            xc.EverestCollimator,
-            xc.EverestCrystal,
-            xt.LimitRect,
-            xt.LimitRacetrack,
-            xt.LimitEllipse,
-            xt.LimitPolygon,
-            xt.LimitRectEllipse,
-            xt.LongitudinalLimitRect,
-            xt.Tracker._get_default_monitor_class()
-    ]
+NO_SYNRAD_ELEMENTS = [
+    Exciter,
+]
 
+# Xfields elements
+DEFAULT_XF_ELEMENTS = [
+    xf.BeamBeamBiGaussian2D,
+    xf.BeamBeamBiGaussian3D,
+    xf.SpaceChargeBiGaussian,
+]
+
+# Xcoll elements
+DEFAULT_XCOLL_ELEMENTS = [
+    # ZetaShift,
+    xc.BlackAbsorber,
+    xc.EverestBlock,
+    xc.EverestCollimator,
+    xc.EverestCrystal,
+    xc.BlowUp,
+    xc.EmittanceMonitor,
+]
+
+NON_TRACKING_ELEMENTS = [
+    RandomUniform,
+    RandomExponential,
+    RandomNormal,
+    RandomRutherford,
+    MultiSetter,
+]
+
+default_element_classes = (
+    ONLY_XTRACK_ELEMENTS
+    + NO_SYNRAD_ELEMENTS
+    + DEFAULT_XF_ELEMENTS
+    + DEFAULT_XCOLL_ELEMENTS
+)
 
 # The class ElementRefData is dynamically generated inside the tracker. We
 # extract it here and use it to create the line metadata inside XbInput
 ElementRefData = xt.tracker._element_ref_data_class_from_element_classes(
-                        default_element_classes)
+    ONLY_XTRACK_ELEMENTS
+    + NO_SYNRAD_ELEMENTS
+    + DEFAULT_XF_ELEMENTS
+    + DEFAULT_XCOLL_ELEMENTS,
+)
 if {f.name for f in ElementRefData._fields} != {'elements', 'names'}:
     raise RunTimeError("The definition of `ElementRefData` has changed inside Xtrack! "
                      + "This renders Xboinc incompatible. Please ask a dev to update Xboinc.")


### PR DESCRIPTION
Minimal update to achieve an updated, functioning executable.
NOTE: a compiled executable was obtained on an Ubuntu 24.04 LTS VM with a Boinc server installed at version 8.3.0. If compiled on other Linux distros, the current Makefile may not work due to different instructions needed to achieve a static executable.

## Description

Minimal changes to update to current Xsuite version.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
