### PR TITLE
Enhance JobRetriever to include job metadata and User check to see if broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ When the jobs are completed, the Xboinc server will store the results in your al
 ```python
 import xboinc as xb
 
-for job_name, result_particles in xb.JobRetriever.iterate("mycernshortname", "a_relevant_study_name", dev_server=True):
+for job_name, job_metadata, result_particles in xb.JobRetriever.iterate("mycernshortname", "a_relevant_study_name", dev_server=True):
     print(f"Job {job_name} completed with particles: {result_particles.to_dict()}")
+    print(f"Job metadata: {job_metadata}")
 
 ```
 

--- a/tests/test_03_submission_and_retrieval.py
+++ b/tests/test_03_submission_and_retrieval.py
@@ -358,7 +358,7 @@ def test_retrieval(registered_user):
         shutil.copy(tar_file, output_dir)
 
     # Iterate through jobs and validate results
-    for _, result_particles in xb.JobRetriever.iterate(
+    for _, _, result_particles in xb.JobRetriever.iterate(
         "testuser", "example_study_fourth", dev_server=True
     ):
         assert len(result_particles.x) == 100

--- a/xboinc/df_wu.py
+++ b/xboinc/df_wu.py
@@ -94,23 +94,23 @@ def query_registered_work_units(
     return all_df
 
 
-def query_subscribed_users() -> list[str]:
+def query_subscribed_users() -> list[tuple[str, str]]:
     """
-    Get a list of all users subscribed to the work unit database.
+    Get a list of all users subscribed to the work unit database with their status.
 
     Returns
     -------
-    list[str]
-        List of usernames subscribed to the work unit database.
+    list[tuple[str, str]]
+        List of tuples containing (username, status) for users subscribed to the work unit database.
     """
     with _get_read_only_user_db_connection() as conn:
         cursor = conn.cursor()
-        cursor.execute("SELECT user FROM users")
-        users = [row[0] for row in cursor.fetchall()]
+        cursor.execute("SELECT user, status FROM users")
+        users = [(row[0], row[1]) for row in cursor.fetchall()]
     return users
 
 
-def check_user_subscription(user: str) -> bool:
+def check_user_subscription(user: str) -> str:
     """
     Check if a user is subscribed to the work unit database.
 
@@ -121,7 +121,12 @@ def check_user_subscription(user: str) -> bool:
 
     Returns
     -------
-    bool
-        True if the user is subscribed, False otherwise.
+    str
+        The status of the user if subscribed, "not_subscribed" otherwise,
+        "broken" if the user's directory is invalid.
     """
-    return user in query_subscribed_users()
+    users = query_subscribed_users()
+    for u, status in users:
+        if u == user:
+            return status
+    return "not_subscribed"

--- a/xboinc/retrieve.py
+++ b/xboinc/retrieve.py
@@ -104,13 +104,22 @@ class JobRetriever:
                 job_name = parts[2]
                 wu_name = bin_file.name.replace(".bin", "")
                 # append to the DataFrame
-                new_row = pd.DataFrame([{
-                    "user": user,
-                    "study_name": study_name,
-                    "job_name": job_name,
-                    "wu_name": wu_name,
-                    "bin_file": bin_file,
-                }])
+                new_row = pd.DataFrame(
+                    [
+                        {
+                            "user": user,
+                            "study_name": study_name,
+                            "job_name": job_name,
+                            "wu_name": wu_name,
+                            "bin_file": bin_file,
+                            "json_file": bin_file.with_name(
+                                bin_file.name.replace(
+                                    "__file_xboinc_state_out.bin", ".json"
+                                )
+                            ),
+                        }
+                    ]
+                )
                 df = pd.concat([df, new_row], ignore_index=True)
         return df
 
@@ -299,8 +308,8 @@ class JobRetriever:
 
         Yields
         ------
-        tuple of (str, xpart.Particles)
-            Job name and corresponding particles object for each result
+        tuple of (str, dict, xpart.Particles)
+            Job name, corresponding metadata, and particles object for each result
 
         Raises
         ------
@@ -324,6 +333,7 @@ class JobRetriever:
         for row in self._df[self._df["study_name"] == study_name].itertuples():
             job_name = row.job_name
             bin_file = row.bin_file
+            json_file = row.json_file
             result = XbState.from_binary(bin_file, raise_version_error=False)
             if result is None:
                 warn(
@@ -332,7 +342,22 @@ class JobRetriever:
                     UserWarning,
                 )
                 continue
-            yield job_name, result.particles
+            try:
+                with open(json_file, "r") as f:
+                    metadata = json.load(f)
+                # is metadata an empty dict?
+                if not metadata:
+                    warn(
+                        f"Warning: The JSON file {json_file} is empty.",
+                        UserWarning,
+                    )
+            except FileNotFoundError:
+                warn(
+                    f"Warning: The JSON file {json_file} was not found.",
+                    UserWarning,
+                )
+                metadata = {}
+            yield job_name, metadata, result.particles
 
     def clean(self, study_name):
         """
@@ -362,6 +387,9 @@ class JobRetriever:
             bin_file = row.bin_file
             if bin_file.exists():
                 bin_file.unlink()
+            json_file = row.json_file
+            if json_file.exists():
+                json_file.unlink()
         # Remove empty directories
         for folder in self._directory.glob("*/"):
             if not any(folder.iterdir()):


### PR DESCRIPTION
Returning job metadata during result iteration, updating user subscription queries to include status, and ensuring related JSON metadata files are properly handled alongside binary result files.

**Job Retrieval and Metadata Improvements:**

* The `JobRetriever.iterate` method now yields a tuple containing the job name, job metadata (from a JSON file), and result particles, instead of just the job name and particles. This change is reflected in both the implementation and usage examples, allowing consumers to access job metadata directly. [[1]](diffhunk://#diff-d57eb03de719bcb612e1683fcf01f27c4bc13cd520f196339ee950cce1fe0898L302-R312) [[2]](diffhunk://#diff-d57eb03de719bcb612e1683fcf01f27c4bc13cd520f196339ee950cce1fe0898L335-R360) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R119) [[4]](diffhunk://#diff-242069100e4b4385a5cad55b80b818718d83bdeb9dc01507bab99b66dad31546L361-R361)
* The internal results indexing now includes a reference to the associated JSON metadata file for each job, enabling easy access during iteration and cleanup. [[1]](diffhunk://#diff-d57eb03de719bcb612e1683fcf01f27c4bc13cd520f196339ee950cce1fe0898L107-R122) [[2]](diffhunk://#diff-d57eb03de719bcb612e1683fcf01f27c4bc13cd520f196339ee950cce1fe0898R336)
* The `clean` method now deletes both the binary result files and their associated JSON metadata files, ensuring a complete cleanup of job artifacts.

**User Subscription Query Enhancements:**

* The `query_subscribed_users` function now returns a list of tuples containing both the username and their subscription status, instead of just usernames. This provides more detailed information about user subscriptions.
* The `check_user_subscription` function now returns the user's subscription status as a string ("not_subscribed" or "broken"), instead of a boolean, allowing for more nuanced handling of user states.